### PR TITLE
Customize local singular host name and port through environment variables

### DIFF
--- a/Vostok.ClusterClient.Singular/ServiceMesh/ServiceMeshEnvironmentInfo.cs
+++ b/Vostok.ClusterClient.Singular/ServiceMesh/ServiceMeshEnvironmentInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using Vostok.Commons.Environment;
 
 #nullable enable
 
@@ -7,6 +8,8 @@ namespace Vostok.Clusterclient.Singular.ServiceMesh
     internal static class ServiceMeshEnvironmentInfo
     {
         private const string UseLocalSingularVariable = "SERVICE_MESH_USE_LOCAL_SINGULAR";
+        private const string LocalSingularHostNameVariable = "SERVICE_MESH_LOCAL_SINGULAR_HOST_NAME";
+        private const string LocalSingularHttpPortVariable = "SERVICE_MESH_LOCAL_SINGULAR_PORT_HTTP";
 
         private static readonly Lazy<bool> LazyUseLocalSingular = new Lazy<bool>(
             () =>
@@ -16,6 +19,29 @@ namespace Vostok.Clusterclient.Singular.ServiceMesh
                 return bool.TryParse(environmentVariable, out var flag) && flag;
             });
 
+        private static readonly Lazy<string> LazyLocalSingularHostName = new Lazy<string>(
+            () =>
+            {
+                var environmentVariable = Environment.GetEnvironmentVariable(LocalSingularHostNameVariable);
+
+                if (!string.IsNullOrWhiteSpace(environmentVariable))
+                    return environmentVariable;
+
+                return EnvironmentInfo.FQDN;
+            });
+
+        private static readonly Lazy<Uri> LazyLocalSingularUri = new Lazy<Uri>(
+            () =>
+            {
+                var httpPortEnvironmentVariable = Environment.GetEnvironmentVariable(LocalSingularHttpPortVariable);
+
+                if (!int.TryParse(httpPortEnvironmentVariable, out var httpPort))
+                    return new Uri($"http://{LazyLocalSingularHostName.Value}");
+
+                return new Uri($"http://{LazyLocalSingularHostName.Value}:{httpPort}");
+            });
+
         public static bool UseLocalSingular => LazyUseLocalSingular.Value;
+        public static Uri LocalSingularUri => LazyLocalSingularUri.Value;
     }
 }

--- a/Vostok.ClusterClient.Singular/ServiceMesh/ServiceMeshRequestModule.cs
+++ b/Vostok.ClusterClient.Singular/ServiceMesh/ServiceMeshRequestModule.cs
@@ -6,7 +6,6 @@ using Vostok.Clusterclient.Core.Modules;
 using Vostok.Clusterclient.Core.Ordering;
 using Vostok.Clusterclient.Core.Strategies;
 using Vostok.Clusterclient.Core.Topology;
-using Vostok.Commons.Environment;
 using Vostok.Logging.Abstractions;
 using Vostok.Singular.Core;
 using Vostok.Singular.Core.PathPatterns.Idempotency;
@@ -111,7 +110,7 @@ namespace Vostok.Clusterclient.Singular.ServiceMesh
 
         private class RequestContextTuner
         {
-            private static readonly FixedClusterProvider LocalSingularClusterProvider = new FixedClusterProvider(new Uri($"http://{EnvironmentInfo.FQDN}"));
+            private static readonly FixedClusterProvider LocalSingularClusterProvider = new FixedClusterProvider(ServiceMeshEnvironmentInfo.LocalSingularUri);
             private static readonly AsIsReplicaOrdering LocalSingularReplicaOrdering = new AsIsReplicaOrdering();
 
             private readonly IClusterProvider fallbackClusterProvider;


### PR DESCRIPTION
We need local singular port customization since default http port on k8s nodes is occupied by ingress controller.